### PR TITLE
handle disconnect if it is called before connection success

### DIFF
--- a/src/Bridge.test.ts
+++ b/src/Bridge.test.ts
@@ -197,25 +197,38 @@ describe("Bridge", () => {
 
         // step 1
         expect(bridge.getState()).toBe(BridgeState.Disconnected);
+        let pms: Promise<any> | null = null;
+        expect(() => pms = bridge.disconnect()).not.toThrow();
 
-        bridge
-            .connect(() => undefined)
+        Promise.resolve()
+            .then(() => {
+                if (pms) {
+                    return pms;
+                }
+            })
+            .then(() => {
+                const promise = bridge
+                    .connect(() => undefined);
+                // step
+                expect(bridge.getState()).toBe(BridgeState.Connecting);
+                return promise;
+            })
             .then(() => {
                 // step 3
                 expect(bridge.getState()).toBe(BridgeState.Connected);
                 expect(() => bridge.connect(() => undefined)).toThrow();
 
-                bridge.disconnect().then(() => {
-                    // step 4
-                    expect(bridge.getState()).toBe(BridgeState.Disconnected);
-                    done();
-                });
+                const promise = bridge.disconnect();
 
                 expect(bridge.getState()).toBe(BridgeState.Disconnecting);
-            });
 
-        // step
-        expect(bridge.getState()).toBe(BridgeState.Connecting);
+                return promise;
+            })
+            .then(() => {
+                // step 4
+                expect(bridge.getState()).toBe(BridgeState.Disconnected);
+                done();
+            });
     });
 
     test("Bridge disconnect before connection success", (done) => {
@@ -233,10 +246,10 @@ describe("Bridge", () => {
         });
 
         bridge.connect(() => undefined)
-          .then(() => {
-              expect(bridge.getState()).toBe(BridgeState.Disconnected);
-              done();
-          });
+            .then(() => {
+                expect(bridge.getState()).toBe(BridgeState.Disconnected);
+                done();
+            });
         bridge.disconnect();
     });
 

--- a/src/Bridge.test.ts
+++ b/src/Bridge.test.ts
@@ -197,7 +197,7 @@ describe("Bridge", () => {
 
         // step 1
         expect(bridge.getState()).toBe(BridgeState.Disconnected);
-        expect(() => bridge.disconnect()).toThrow();
+        // expect(() => bridge.disconnect()).toThrow();
 
         bridge
             .connect(() => undefined)
@@ -217,6 +217,28 @@ describe("Bridge", () => {
 
         // step
         expect(bridge.getState()).toBe(BridgeState.Connecting);
+    });
+
+    test("Bridge disconnect before connection success", (done) => {
+        const bridge = new Bridge({
+            connect: () => new Promise((resolve) => {
+                // connect after 20ms
+                setTimeout(() => resolve(), 20);
+            }),
+            disconnect: () => new Promise((resolve) => {
+                // disconnect after 10ms
+                setTimeout(() => resolve(), 10);
+            }),
+            send: () => undefined,
+            timeout: 30,
+        });
+
+        bridge.connect(() => undefined)
+          .then(() => {
+              expect(bridge.getState()).toBe(BridgeState.Disconnected);
+              done();
+          });
+        bridge.disconnect();
     });
 
     test("Bridge.send()", (done) => {

--- a/src/Bridge.test.ts
+++ b/src/Bridge.test.ts
@@ -197,7 +197,6 @@ describe("Bridge", () => {
 
         // step 1
         expect(bridge.getState()).toBe(BridgeState.Disconnected);
-        // expect(() => bridge.disconnect()).toThrow();
 
         bridge
             .connect(() => undefined)

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -170,6 +170,10 @@ export class Bridge implements IBridge {
             makeAttempt(1);
         })
             .then(() => {
+                if (this.state !== BridgeState.AwaitingConnect && this.state !== BridgeState.Connecting) {
+                    // disconnected was called before connection succeeded, avoid setting connected state
+                    return;
+                }
                 this.messageHandler = handler;
                 this.state = BridgeState.Connected;
             })

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -186,10 +186,6 @@ export class Bridge implements IBridge {
     }
 
     public disconnect(): Promise<void> {
-        if (this.state !== BridgeState.Connected) {
-            throw new Error("invalid request");
-        }
-
         this.state = BridgeState.Disconnecting;
 
         return this.options.disconnect().then(() => {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -157,6 +157,10 @@ export class Bridge implements IBridge {
 
         return new Promise((resolve, reject) => {
             const makeAttempt = (currentAttempt: number): void => {
+                if (this.state !== BridgeState.AwaitingConnect && this.state !== BridgeState.Connecting) {
+                    return resolve();
+                }
+
                 this.options.connect(awaitConnection)
                     .then(() => resolve())
                     .catch((err) => {


### PR DESCRIPTION
The use case for this: if for any reason `.connect()` promise is not resolved yet, but player removes the `App` container from the screen, the bridge must be disconnected and cleaned up, which is not happening with current code in master.