### PR TITLE
44 runtime typechecking enclodepostmesssagebridgecommand

### DIFF
--- a/src/PostMessageBridge.test.ts
+++ b/src/PostMessageBridge.test.ts
@@ -35,10 +35,6 @@ const makeWindow = (): Window => (new FakeWindow() as any);
 test("encodePostMessageBridgeCommand()", () => {
     expect(encodePostMessageBridgeCommand("foo" as any)).toEqual(`___{"type":"foo"}`);
     expect(encodePostMessageBridgeCommand("foo" as any, 17)).toEqual(`___{"type":"foo","data":17}`);
-
-    expect(() => encodePostMessageBridgeCommand(17 as any)).toThrow();
-    expect(() => encodePostMessageBridgeCommand(undefined as any)).toThrow();
-    expect(() => encodePostMessageBridgeCommand({} as any)).toThrow();
 });
 
 test("tryDecodePostMessageBridgeCommand()", () => {

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -21,9 +21,6 @@ export function tryDecodePostMessageBridgeCommand(obj: any): undefined | IPostMe
 }
 
 export function encodePostMessageBridgeCommand(type: PostMessageBridgeCommandTypes, data?: any): string {
-    if (!type || !isString(type)) {
-        throw new Error(`command must be a string`);
-    }
     return `___${JSON.stringify({type, data})}`;
 }
 


### PR DESCRIPTION
closes #44 
`type` argument is already checked at compile time, so no need to do runtime check.