### PR TITLE
WIP 40 xss amelioration

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -4,7 +4,6 @@ import isFunction from "lodash/isFunction";
 import isNumber from "lodash/isNumber";
 import isObjectLike from "lodash/isObjectLike";
 import isPlainObject from "lodash/isPlainObject";
-import {validMessageDomains} from "./config";
 import {IMessage} from "./MessageApp";
 
 export interface IBridge {
@@ -54,18 +53,15 @@ export interface IBridgeOptions {
     send: (request: string) => void;
     encode?: (obj: IBridgeMessage) => string;
     decode?: (str: string) => IBridgeMessage;
-    verifyDomain?: (options: { origin: string, validDomains: string[] }) => boolean;
 }
 
 export function isBridgeOptions(obj: any): obj is IBridgeOptions {
     return (
         isObjectLike(obj) &&
         // required functions
-        ["connect", "disconnect", "send"].every((methodName) =>
-            isFunction(obj[methodName]),
-        ) &&
+        ["connect", "disconnect", "send"].every((methodName) => isFunction(obj[methodName])) &&
         // optional functions
-        ["encode", "decode", "verifyDomain"].every(
+        ["encode", "decode"].every(
             (methodName) => obj[methodName] === undefined || isFunction(obj[methodName]),
         ) &&
         isNumber(obj.timeout) &&
@@ -100,21 +96,6 @@ export function isBridge(obj: any): obj is IBridge {
 
     return requiredProps.every((propName) => hasIn(obj, propName) && !isFunction(obj[propName]))
         && requiredFuncs.every((funcName) => isFunction(obj[funcName]));
-}
-
-export interface IVerifyDomain {
-    origin: string;
-    validDomains: string[];
-}
-
-// Verify if origin URL is in the allowed validDomains list to send/receive messages
-export function defaultVerifyDomain({origin, validDomains = validMessageDomains}: IVerifyDomain) {
-    const escapedAndConcattedDomains = validDomains
-        .map((domain) => domain.replace(/\./gi, "\."))
-        .join("|");
-    const re = RegExp(`^(${escapedAndConcattedDomains})$`, "i");
-
-    return re.test(origin);
 }
 
 export enum BridgeState {
@@ -154,8 +135,6 @@ export class Bridge implements IBridge {
         if (!isBridgeOptions(options)) {
             throw new Error("invalid argument options");
         }
-
-        options.verifyDomain = options.verifyDomain || defaultVerifyDomain;
 
         this.options = options;
     }

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -107,7 +107,10 @@ export class PostMessageBridge extends Bridge {
                 resolve();
             }),
             send: (request: string) => {
-                PostMessageBridge.validPostMessageDomains.forEach((domain) => this.target.postMessage(request, domain));
+                // Send one message to every domain in whitelist, because we're not
+                // sure what's on the other end. Messages not intended for recipient
+                // PostMessageBridge will just be lost in the ether.
+                validMessageDomains.forEach(domain => this.target.postMessage(request, domain));
             },
             timeout,
         });

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -156,16 +156,16 @@ export class PostMessageBridge extends Bridge {
     }
 
     protected handleMessageEvent = (event: MessageEvent): void => {
-        if (!this.verifyDomain({ origin: event.origin })) {
+        const { origin, source, data } = event;
+
+        if (!this.verifyDomain({ origin })) {
             return;
         }
 
         // source is unexpected?
-        if (event.source !== this.target) {
+        if (source !== this.target) {
             return;
         }
-
-        const {data} = event;
 
         const command = tryDecodePostMessageBridgeCommand(data);
 

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -168,4 +168,26 @@ export class PostMessageBridge extends Bridge {
             this.eventListenersAdded = false;
         }
     }
+
+    private isGoodOrigin(origin: string) {
+        // Ideally this could also be gotten from app manifest `start_url`,
+        // but we do not use that ourselves except as relative URL
+        const validPostMessageDomains = [
+            "https://apps-services.screencloudapp.com/",
+            "https://apps-backends-production.screen.cloud/",
+            "https://apps-services.staging.screencloudapp.com/",
+            "https://apps-backends-staging.screen.cloud/",
+            "https://studio.staging.next.sc/",
+            "https://studio.edge.next.sc/",
+            "https://studio.screencloud.com/"
+        ];
+
+        // Be careful to escape every "."
+        const escapeDotsAndConcat = validPostMessageDomains
+            .map((domain) => domain.replace(/\./gi, "."))
+            .join("|");
+        const re = RegExp(`^(${escapeDotsAndConcat})$`, "i");
+
+        return re.test(origin);
+    }
 }

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -82,7 +82,7 @@ export class PostMessageBridge extends Bridge {
                 resolve();
             }),
             send: (request: string) => {
-                this.target.postMessage(request, "*");
+                PostMessageBridge.validPostMessageDomains.forEach((domain) => this.target.postMessage(request, domain));
             },
             timeout,
         });

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -130,6 +130,10 @@ export class PostMessageBridge extends Bridge {
     }
 
     protected handleMessageEvent = (event: MessageEvent): void => {
+        if (!this.isGoodOrigin(event.origin)) {
+            return;
+        }
+
         // source is unexpected?
         if (event.source !== this.target) {
             return;

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -150,7 +150,7 @@ export class PostMessageBridge extends Bridge {
     }
 
     protected handleMessageEvent = (event: MessageEvent): void => {
-        if (!this.isGoodOrigin(event.origin)) {
+        if (!this.verifyDomain(event.origin)) {
             return;
         }
 

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -28,15 +28,24 @@ export function encodePostMessageBridgeCommand(type: PostMessageBridgeCommandTyp
 }
 
 export class PostMessageBridge extends Bridge {
-
+    // Note: terminating "/" or port number is mandatory
     private static validPostMessageDomains = [
         "https://apps-services.screencloudapp.com/",
         "https://apps-backends-production.screen.cloud/",
         "https://apps-services.staging.screencloudapp.com/",
         "https://apps-backends-staging.screen.cloud/",
-        "https://studio.staging.next.sc/",
+        "https://screencloud-testing.auth0.com/",
+        "https://authenticate.next.sc/",
+        "https://studio.dev.next.sc:3000",
+        "https://studio.dev.next.sc/",
         "https://studio.edge.next.sc/",
-        "https://studio.screencloud.com/"
+        "https://studio.staging.next.sc/",
+        "https://studio.screencloud.com/",
+        "https://mc.dev.next.sc:3001",
+        "https://mc.dev.next.sc/",
+        "https://mc.edge.next.sc/",
+        "https://mc.staging.next.sc/",
+        "https://mc.screencloud.com/"
     ];
 
     protected targetWindow: Window | null = null;

--- a/src/PostMessageBridge.ts
+++ b/src/PostMessageBridge.ts
@@ -29,8 +29,17 @@ export function encodePostMessageBridgeCommand(type: PostMessageBridgeCommandTyp
 
 export class PostMessageBridge extends Bridge {
 
-    protected targetWindow: Window | null = null;
+    private static validPostMessageDomains = [
+        "https://apps-services.screencloudapp.com/",
+        "https://apps-backends-production.screen.cloud/",
+        "https://apps-services.staging.screencloudapp.com/",
+        "https://apps-backends-staging.screen.cloud/",
+        "https://studio.staging.next.sc/",
+        "https://studio.edge.next.sc/",
+        "https://studio.screencloud.com/"
+    ];
 
+    protected targetWindow: Window | null = null;
     protected sourceWindow: Window | null = null;
 
     protected eventListenersAdded: boolean = false;
@@ -176,18 +185,9 @@ export class PostMessageBridge extends Bridge {
     private isGoodOrigin(origin: string) {
         // Ideally this could also be gotten from app manifest `start_url`,
         // but we do not use that ourselves except as relative URL
-        const validPostMessageDomains = [
-            "https://apps-services.screencloudapp.com/",
-            "https://apps-backends-production.screen.cloud/",
-            "https://apps-services.staging.screencloudapp.com/",
-            "https://apps-backends-staging.screen.cloud/",
-            "https://studio.staging.next.sc/",
-            "https://studio.edge.next.sc/",
-            "https://studio.screencloud.com/"
-        ];
 
         // Be careful to escape every "."
-        const escapeDotsAndConcat = validPostMessageDomains
+        const escapeDotsAndConcat = PostMessageBridge.validPostMessageDomains
             .map((domain) => domain.replace(/\./gi, "."))
             .join("|");
         const re = RegExp(`^(${escapeDotsAndConcat})$`, "i");

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 // Note: terminating "/" or port number is mandatory
 export const validMessageDomains = [
+    "https://js.stripe.com/",
     "https://apps-services.screencloudapp.com/",
     "https://apps-backends-production.screen.cloud/",
     "https://apps-services.staging.screencloudapp.com/",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
+// Note: terminating "/" or port number is mandatory
 export const validMessageDomains = [
-    // Note: terminating "/" or port number is mandatory
     "https://apps-services.screencloudapp.com/",
     "https://apps-backends-production.screen.cloud/",
     "https://apps-services.staging.screencloudapp.com/",
@@ -15,5 +15,5 @@ export const validMessageDomains = [
     "https://mc.dev.next.sc/",
     "https://mc.edge.next.sc/",
     "https://mc.staging.next.sc/",
-    "https://mc.screencloud.com/"
+    "https://mc.screencloud.com/",
 ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,19 @@
+export const validMessageDomains = [
+    // Note: terminating "/" or port number is mandatory
+    "https://apps-services.screencloudapp.com/",
+    "https://apps-backends-production.screen.cloud/",
+    "https://apps-services.staging.screencloudapp.com/",
+    "https://apps-backends-staging.screen.cloud/",
+    "https://screencloud-testing.auth0.com/",
+    "https://authenticate.next.sc/",
+    "https://studio.dev.next.sc:3000",
+    "https://studio.dev.next.sc/",
+    "https://studio.edge.next.sc/",
+    "https://studio.staging.next.sc/",
+    "https://studio.screencloud.com/",
+    "https://mc.dev.next.sc:3001",
+    "https://mc.dev.next.sc/",
+    "https://mc.edge.next.sc/",
+    "https://mc.staging.next.sc/",
+    "https://mc.screencloud.com/"
+];


### PR DESCRIPTION
# Looking for feedback :small_airplane: :small_airplane: :small_airplane: 

addresses (but doesn't yet close #40)

and https://github.com/screencloud/auth-next-frontend/issues/131

So to summarize few issues here:

-   We send messages with any targetOrigin
-   We receive messages and only verify the source

<a id="org3ac1ff3"></a>

# Proposed solution

The whitelist approach is the simplest one I could think of, but as Michael
raises, this won&rsquo;t work if customers are hosting their own apps. I don&rsquo;t think
it would be *too* difficult to just manually add customer domains as needed, as it&rsquo;s
doubtful this would grow into 4 digits or higher.

The valid domains list could come from somewhere else, e.g. `process.env` or
similar. In the function here is probably not the best place. It would be easy
to forget to change this and have accidental breakage.

I don&rsquo;t think this can come from the app `manifest.json` because the `start_url`
key in these are set to &ldquo;.&rdquo; This &ldquo;.&rdquo; will just grab the `index.html` in the
current folder, which itself has a `%PUBLIC_URL%` template string filled in by
`process.env.PUBLIC_URL`.

It&rsquo;s also not necessarily even used by the user agent.

> The start<sub>url</sub> member is purely advisory, and a user agent may ignore it or allow the user to alter it at install time or afterwards


<a id="org901dd59"></a>

## Message sending

For  the sending of messages, it seems that we would need to run
`this.target.postMessage(request, "*")` multiple times for each `send` event with the `*` replaced
with each potential source domain. Invalid domains would not receive this.

Otherwise, per my reading, browser extensions, etc. could receive this message.
Not sure if we&rsquo;re doing anything sensitive in these messages in particular.


<a id="orge8539cd"></a>

## Message receiving

Should be solved by checking `event.origin` against whitelist


<a id="orgca93dfa"></a>

# Other potential solutions:

1.  Split implementations so that there is a parentBridge and childBridge so that we

always know that the child&rsquo;s information is trustworthy, and the parent&rsquo;s is
not necessarily. As it stands with only one implementation for both, we cannot do this.

1.  Something something store it in the jwt. Not sure what this looks like given
    that you would still need a whitelist to check against the domain in the jwt.

# Update:

Proper domain list already exists in https://github.com/screencloud/auth-next-frontend/blob/master/src/appConfig.ts