### PR TITLE
clear handlers on disconnect

### DIFF
--- a/src/MessageApp.ts
+++ b/src/MessageApp.ts
@@ -100,6 +100,8 @@ export class MessageApp<MessageTypes = any, MessageHandlers extends IMessageHand
     }
 
     public disconnect(): Promise<void> {
+        this.handlers = {};
+
         return this.bridge.disconnect();
     }
 


### PR DESCRIPTION
since handlers are not private, we clear the reference on disconnect to make sure those methods are not stuck anywhere